### PR TITLE
chore: migrate to zoobz-io org and standardize configs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: ${{ secrets.RELEASE_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Tag submodules
       run: |


### PR DESCRIPTION
## Summary
- Migrate module path and all imports from `github.com/zoobzio/herald` to `github.com/zoobz-io/herald`
- Update all 12 submodule go.mod files (root + amqp, bolt, firestore, io, jetstream, kafka, nats, pubsub, redis, sns, sqs)
- Update all dependency references (capitan v1.0.2, pipz v1.0.5, clockz v1.0.2)
- Standardize CI, CodeQL, coverage, and release workflows to org gold standard
- Use GITHUB_TOKEN for submodule tagging in release workflow
- Standardize Makefile with security scanning target
- Update .goreleaser.yml owner to zoobz-io with GORELEASER_CURRENT_TAG
- Add settings.yml with homepage and labels
- Update CODEOWNERS
- Remove PR/issue templates and version-preview workflow
- Update all documentation references

## Test plan
- [x] All tests pass locally with `go test -tags testing -race ./...`
- [ ] CI workflow runs successfully
- [ ] Coverage workflow runs successfully
- [ ] CodeQL analysis completes