### PR TITLE
feat: add Redis Pub/Sub provider

### DIFF
--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -1,0 +1,114 @@
+package redis
+
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/zoobz-io/herald"
+)
+
+// PubSubProvider implements herald.Provider for Redis Pub/Sub.
+// Unlike the Streams provider, Pub/Sub is ephemeral — messages are
+// lost if no subscriber is listening. Every subscriber receives every
+// message (broadcast semantics).
+type PubSubProvider struct {
+	client  *redis.Client
+	sub     *redis.PubSub
+	channel string
+}
+
+// PubSubOption configures a PubSubProvider.
+type PubSubOption func(*PubSubProvider)
+
+// WithPubSubClient sets the Redis client.
+func WithPubSubClient(c *redis.Client) PubSubOption {
+	return func(p *PubSubProvider) {
+		p.client = c
+	}
+}
+
+// NewPubSub creates a Redis Pub/Sub provider for the given channel.
+func NewPubSub(channel string, opts ...PubSubOption) *PubSubProvider {
+	p := &PubSubProvider{
+		channel: channel,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Publish sends raw bytes to a Redis Pub/Sub channel.
+// Note: Redis Pub/Sub does not support metadata; metadata is ignored.
+func (p *PubSubProvider) Publish(ctx context.Context, data []byte, metadata herald.Metadata) error {
+	if p.client == nil {
+		return herald.ErrNoWriter
+	}
+	return p.client.Publish(ctx, p.channel, data).Err()
+}
+
+// Subscribe returns a stream of messages from a Redis Pub/Sub channel.
+func (p *PubSubProvider) Subscribe(ctx context.Context) <-chan herald.Result[herald.Message] {
+	out := make(chan herald.Result[herald.Message])
+
+	if p.client == nil {
+		go func() {
+			out <- herald.NewError[herald.Message](herald.ErrNoReader)
+			close(out)
+		}()
+		return out
+	}
+
+	p.sub = p.client.Subscribe(ctx, p.channel)
+
+	go func() {
+		defer close(out)
+
+		ch := p.sub.Channel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-ch:
+				if !ok {
+					return
+				}
+				heraldMsg := herald.Message{
+					Data: []byte(msg.Payload),
+					Ack: func() error {
+						return nil
+					},
+					Nack: func() error {
+						return nil
+					},
+				}
+				select {
+				case out <- herald.NewSuccess(heraldMsg):
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return out
+}
+
+// Ping verifies Redis connectivity.
+func (p *PubSubProvider) Ping(ctx context.Context) error {
+	if p.client == nil {
+		return herald.ErrNoWriter
+	}
+	return p.client.Ping(ctx).Err()
+}
+
+// Close releases Redis Pub/Sub resources.
+func (p *PubSubProvider) Close() error {
+	if p.sub != nil {
+		_ = p.sub.Close()
+	}
+	if p.client != nil {
+		return p.client.Close()
+	}
+	return nil
+}

--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/zoobz-io/herald"
@@ -104,11 +105,12 @@ func (p *PubSubProvider) Ping(ctx context.Context) error {
 
 // Close releases Redis Pub/Sub resources.
 func (p *PubSubProvider) Close() error {
+	var subErr error
 	if p.sub != nil {
-		_ = p.sub.Close()
+		subErr = p.sub.Close()
 	}
 	if p.client != nil {
-		return p.client.Close()
+		return errors.Join(subErr, p.client.Close())
 	}
-	return nil
+	return subErr
 }

--- a/redis/pubsub_test.go
+++ b/redis/pubsub_test.go
@@ -1,0 +1,163 @@
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestPubSubProvider_Publish(t *testing.T) {
+	client := setupRedis(t)
+	channel := "herald-test-pubsub-publish"
+
+	provider := NewPubSub(channel, WithPubSubClient(client))
+
+	err := provider.Publish(context.Background(), []byte(`{"test":"data"}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPubSubProvider_PublishNoClient(t *testing.T) {
+	provider := NewPubSub("test-channel")
+
+	err := provider.Publish(context.Background(), []byte(`{"test":"data"}`), nil)
+	if err == nil {
+		t.Fatal("expected error with nil client")
+	}
+}
+
+func TestPubSubProvider_Subscribe(t *testing.T) {
+	client := setupRedis(t)
+	channel := "herald-test-pubsub-subscribe"
+
+	provider := NewPubSub(channel, WithPubSubClient(client))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := provider.Subscribe(ctx)
+
+	// Give the subscription time to establish
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish messages after subscribing
+	client.Publish(context.Background(), channel, `{"order":"1"}`)
+	client.Publish(context.Background(), channel, `{"order":"2"}`)
+
+	var received [][]byte
+	for i := 0; i < 2; i++ {
+		select {
+		case result := <-ch:
+			if result.IsError() {
+				t.Fatalf("unexpected error: %v", result.Error())
+			}
+			received = append(received, result.Value().Data)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout")
+		}
+	}
+
+	cancel()
+
+	if len(received) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(received))
+	}
+
+	if string(received[0]) != `{"order":"1"}` {
+		t.Errorf("unexpected first message: %s", received[0])
+	}
+	if string(received[1]) != `{"order":"2"}` {
+		t.Errorf("unexpected second message: %s", received[1])
+	}
+}
+
+func TestPubSubProvider_SubscribeNoClient(t *testing.T) {
+	provider := NewPubSub("test-channel")
+
+	ctx := context.Background()
+	ch := provider.Subscribe(ctx)
+
+	result, ok := <-ch
+	if !ok {
+		t.Fatal("expected error result before close")
+	}
+	if !result.IsError() {
+		t.Error("expected error result")
+	}
+
+	_, ok = <-ch
+	if ok {
+		t.Error("expected closed channel after error")
+	}
+}
+
+func TestPubSubProvider_AckNack(t *testing.T) {
+	client := setupRedis(t)
+	channel := "herald-test-pubsub-ack"
+
+	provider := NewPubSub(channel, WithPubSubClient(client))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := provider.Subscribe(ctx)
+
+	time.Sleep(100 * time.Millisecond)
+
+	client.Publish(context.Background(), channel, `{"test":"ack"}`)
+
+	select {
+	case result := <-ch:
+		if result.IsError() {
+			t.Fatalf("unexpected error: %v", result.Error())
+		}
+		msg := result.Value()
+		if err := msg.Ack(); err != nil {
+			t.Errorf("ack should be no-op: %v", err)
+		}
+		if err := msg.Nack(); err != nil {
+			t.Errorf("nack should be no-op: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestPubSubProvider_Ping(t *testing.T) {
+	client := setupRedis(t)
+	provider := NewPubSub("test-channel", WithPubSubClient(client))
+
+	err := provider.Ping(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPubSubProvider_PingNoClient(t *testing.T) {
+	provider := NewPubSub("test-channel")
+
+	err := provider.Ping(context.Background())
+	if err == nil {
+		t.Fatal("expected error with nil client")
+	}
+}
+
+func TestPubSubProvider_Close(t *testing.T) {
+	client := setupRedis(t)
+	provider := NewPubSub("test-channel", WithPubSubClient(client))
+
+	err := provider.Close()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPubSubProvider_CloseNil(t *testing.T) {
+	provider := NewPubSub("test-channel")
+
+	err := provider.Close()
+	if err != nil {
+		t.Fatalf("unexpected error with nil client: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `NewPubSub(channel, ...PubSubOption)` constructor in `redis/` package alongside existing Streams provider
- Implements `herald.Provider` using Redis `PUBLISH`/`SUBSCRIBE` commands for broadcast semantics
- No-op Ack/Nack (Pub/Sub has no acknowledgment model), metadata ignored (same pattern as NATS Core)
- Full test suite using testcontainers: publish, subscribe roundtrip, ack/nack no-ops, ping, close, nil-client error paths

## Test plan

- [x] All 9 new PubSub provider tests pass
- [x] All 7 existing Streams provider tests still pass
- [x] Package compiles cleanly

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)